### PR TITLE
build: linux/amd64 build

### DIFF
--- a/develop/docker-build.sh
+++ b/develop/docker-build.sh
@@ -14,7 +14,7 @@ check_file $pyproject_toml
 PACKAGE_VERSION=$(egrep '^version' $pyproject_toml | awk -F '=' '{print $NF}'  | sed s'/"//'g | xargs)
 PACKAGE_NAME='clickhouse-table-exporter'
 
-docker build --build-arg="PACKAGE_VERSION=$PACKAGE_VERSION" --tag ${PACKAGE_NAME} .
+docker build --build-arg="PACKAGE_VERSION=$PACKAGE_VERSION" --platform linux/amd64 --tag ${PACKAGE_NAME} .
 docker tag $PACKAGE_NAME:latest $PACKAGE_NAME:$PACKAGE_VERSION
 
 # Upload to docker hub

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "clickhouse_table_exporter"
-version = "20230917"
+version = "20240620"
 dependencies = [
     "clickhouse-connect>=0.6.7",
     "prometheus_client>=0.17.1"


### PR DESCRIPTION
It fixes https://github.com/alexeyantropov/clickhouse_table_exporter/issues/6 issue, now all builds are made for linux/amd64 istead of linux/arm64/v8 as in the past.